### PR TITLE
feat(htl): adding HTL template example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs
 test-results.xml
 .hlx
 helix-config.yaml.old
+.env

--- a/src/html.htl
+++ b/src/html.htl
@@ -7,16 +7,24 @@
     <title>${content.title}</title>
     <link rel="stylesheet" href="/style.css"/>
 </head>
-<body>
+<body data-sly-use.lib="./templates/library.html">
 
 ${content.document.body.innerHTML}
 
 <hr>
-<em>Helix generated this on:${content.time}</em>
+<em>Helix generated this on:${content.data.time}</em>
 <br/>
-<em>This is random: ${content.random}</em>
+<em>This is random: ${content.data.random}</em>
 <br/>
-<em>This is dynamically generated: ${content.fromPreJS}</em>
+<em>This is dynamically generated: ${content.data.fromPreJS}</em>
+<br/>
+<div>
+    <!--/* call the lib.button template and pass in the button text */-->
+    Click here to <span data-sly-call="${lib.button @ text='Win big pizza!'}"></span>
+</div>
+<hr>
+See our <sly data-sly-call="${lib.link @ text='documentation', href=content.data.homepage}"></sly>
+for more information.
 
 </body>
 </html>

--- a/src/html.htl
+++ b/src/html.htl
@@ -26,5 +26,14 @@ ${content.document.body.innerHTML}
 See our <sly data-sly-call="${lib.link @ text='documentation', href=content.data.homepage}"></sly>
 for more information.
 
+<hr>
+<!--/* example of how to use "use" classes */-->
+<h3 data-sly-use.unknown="${'./planet.js'}">${unknown.title}</h3>
+<h3 data-sly-use.jupiter="${'./planet.js' @ jcr:title='Jupiter', value1='Moon', value2='Europa', radius='70000'}">
+    ${jupiter.title}
+</h3>
+<p>${jupiter.subTitle}</p>
+<p>Surface Area: ${jupiter.area}</p>
+
 </body>
 </html>

--- a/src/html.pre.js
+++ b/src/html.pre.js
@@ -10,25 +10,28 @@
  * governing permissions and limitations under the License.
  */
 
-var counter = 0;
+let counter = 0;
 
- // pre can be used to compute dynamic content properties
- module.exports.pre = context => {
-  context.content.fromPreJS = "This comes from pre.js";
-  context.content.time = `${new Date()}`;
-  context.content.random = `${43 + Math.random()}`;
-}
+// pre can be used to compute dynamic content properties
+module.exports.pre = context => {
+  context.content.data = {
+    fromPreJS: "This comes from pre.js",
+    time: `${new Date()}`,
+    random: `${43 + Math.random()}`,
+    homepage: 'https://www.project-helix.io/',
+  }
+};
 
 // demonstrate hooking the before ESI pipeline stage
 module.exports.before = {
   esi: (context) => {
     context.response.headers['X-marker-before'] = `esi/${counter++}`;
-  }
-}
+  },
+};
 
 // demonstrate hooking the after ESI pipeline stage
 module.exports.after = {
   esi: (context) => {
     context.response.headers['X-marker-after'] = `esi/${counter++}`;
-  }
-}
+  },
+};

--- a/src/planet.js
+++ b/src/planet.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+module.exports = class Planet {
+  use() {
+    const r = Number(this.radius);
+
+    return {
+      title: this['jcr:title'] || 'Untitled',
+      subTitle: `${this.value1}: ${this.value2}`,
+      get area() {
+        return 4 * Math.PI * r * r;
+      },
+    };
+  }
+};

--- a/src/templates/button.html
+++ b/src/templates/button.html
@@ -1,0 +1,14 @@
+<!--
+  ~ Copyright 2019 Adobe. All rights reserved.
+  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under
+  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  ~ OF ANY KIND, either express or implied. See the License for the specific language
+  ~ governing permissions and limitations under the License.
+  -->
+<template data-sly-template.button="${@ text}">
+    <button>${text}</button>
+</template>

--- a/src/templates/library.html
+++ b/src/templates/library.html
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright 2019 Adobe. All rights reserved.
+  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under
+  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  ~ OF ANY KIND, either express or implied. See the License for the specific language
+  ~ governing permissions and limitations under the License.
+  -->
+<sly data-sly-use.lib="./button.html"></sly>
+<sly data-sly-use.lib="./link.html"></sly>

--- a/src/templates/link.html
+++ b/src/templates/link.html
@@ -1,0 +1,14 @@
+<!--
+  ~ Copyright 2019 Adobe. All rights reserved.
+  ~ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License. You may obtain a copy
+  ~ of the License at http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under
+  ~ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  ~ OF ANY KIND, either express or implied. See the License for the specific language
+  ~ governing permissions and limitations under the License.
+  -->
+<template data-sly-template.link="${@ text, href}">
+    <a href="${href}">${text}</a>
+</template>


### PR DESCRIPTION
- adding example of how to use (external) HTL templates
- modifying `context.content` directly is discouraged, thus adding the user defined data to `context.content.data`
- adding `.env` to `.gitignore`
